### PR TITLE
Wrap function name in get-function()

### DIFF
--- a/sass/_pow-polyfill.scss
+++ b/sass/_pow-polyfill.scss
@@ -45,7 +45,7 @@
   $sum: 0;
 
   @for $index from $initial to $limit {
-    $sum: $sum + call($iteratee, $input, $index);
+    $sum: $sum + call(get-function($iteratee), $input, $index);
   }
 
   @return $sum;


### PR DESCRIPTION
Calling string names of functions with `call()` is deprecated in Sass 3.5 and will break in Sass 4.0.

**[Sass 3.5 CHANGELOG](http://sass-lang.com/documentation/file.SASS_CHANGELOG.html#3_5_0__12_July_2017_):**
> Passing a string to call($function-name, $args...) indicating which function to invoke is now deprecated. Instead pass a function reference returned from get-function($function-name). This allows function name resolution to be performed in the correct lexical context and then invoked in a different context. This is required so that the module-based resolver in Sass 4.0 will invoke the correct function when calling across module boundaries. Developers of frameworks that use call should not do the function lookup for callers of their framework; this is likely to result in a situation where the framework cannot resolve the function in 4.0.