### PR TITLE
greatly improve performance by avoiding unnecessary duplication

### DIFF
--- a/sass/_pow-polyfill.scss
+++ b/sass/_pow-polyfill.scss
@@ -6,11 +6,17 @@
 //
 
 @function math-pow-polyfill($number, $exp) {
-  @if (round($exp) != $exp) {
-    @return math-exp($exp * math-ln($number));
+  $exp1: round($exp);
+  $result: pow-int($number, $exp1);
+
+  @if ($exp1 != $exp) {
+    $result: $result * math-exp(($exp - $exp1) * math-ln($number));
   }
 
-  // Traditional method for integers
+  @return $result;
+}
+
+@function pow-int($number, $exp) {
   @if $exp == 0 {
     @return 1;
   }

--- a/sass/_pow-polyfill.scss
+++ b/sass/_pow-polyfill.scss
@@ -41,27 +41,13 @@
   @return $result;
 }
 
-@function math-summation($iteratee, $input, $initial: 0, $limit: 100) {
-  $sum: 0;
+@function math-exp($value) {
+  $result: 0;
 
-  @for $index from $initial to $limit {
-    $sum: $sum + call(get-function($iteratee), $input, $index);
+  @for $index from 0 to 100 {
+    $result: $result + math-pow-polyfill($value, $index) / math-factorial($index);
   }
 
-  @return $sum;
-}
-
-@function math-exp-maclaurin($x, $n) {
-  $result: math-pow-polyfill($x, $n) / math-factorial($n);
-  @return $result;
-}
-@function math-exp($value) {
-  $result: math-summation(math-exp-maclaurin, $value, 0, 100);
-  @return $result;
-}
-
-@function math-ln-maclaurin($x, $n) {
-  $result: (math-pow-polyfill(-1, $n + 1) / $n) * (math-pow-polyfill($x - 1, $n));
   @return $result;
 }
 
@@ -75,7 +61,11 @@
 
   $value: $value / math-pow-polyfill(10, $ten-exp);
 
-  $result: math-summation(math-ln-maclaurin, $value, 1, 100);
+  $result: 0;
+
+  @for $index from 1 to 100 {
+    $result: $result + (math-pow-polyfill(-1, $index + 1) / $index) * (math-pow-polyfill($value - 1, $index));
+  }
 
   @return $result + $ten-exp * $ln-ten;
 }

--- a/sass/_pow-polyfill.scss
+++ b/sass/_pow-polyfill.scss
@@ -11,41 +11,30 @@
   }
 
   // Traditional method for integers
-  $value: 1;
-
-  @if $exp > 0 {
-    @for $i from 1 through $exp {
-      $value: $value * $number;
-    }
-  }
-  @else if $exp < 0 {
-    @for $i from 1 through -$exp {
-      $value: $value / $number;
-    }
-  }
-
-  @return $value;
-}
-
-@function math-factorial($value) {
-  @if $value == 0 {
+  @if $exp == 0 {
     @return 1;
   }
-
-  $result: 1;
-
-  @for $index from 1 through $value {
-    $result: $result * $index;
+  @else if $exp < 0 {
+    @return 1 / math-pow-polyfill($number, -$exp);
   }
-
-  @return $result;
+  @else {
+    $e: floor($exp / 2);
+    $pow: math-pow-polyfill($number, $e);
+    @if $e * 2 == $exp {
+        @return $pow * $pow;
+    } @else {
+        @return $pow * $pow * $number;
+    }
+  }
 }
 
 @function math-exp($value) {
-  $result: 0;
+  $item: 1;
+  $result: 1;
 
-  @for $index from 0 to 100 {
-    $result: $result + math-pow-polyfill($value, $index) / math-factorial($index);
+  @for $index from 1 to 100 {
+    $item: $item * $value / $index;
+    $result: $result + $item;
   }
 
   @return $result;
@@ -61,10 +50,12 @@
 
   $value: $value / math-pow-polyfill(10, $ten-exp);
 
+  $item: -1;
   $result: 0;
 
   @for $index from 1 to 100 {
-    $result: $result + (math-pow-polyfill(-1, $index + 1) / $index) * (math-pow-polyfill($value - 1, $index));
+    $item: $item * (1 - $value);
+    $result: $result + $item / $index;
   }
 
   @return $result + $ten-exp * $ln-ten;


### PR DESCRIPTION
I used this simple script to test:

```
@for $i from 0 to 10 {
  $_: math-pow-polyfill(0.142, 0.718273912);
  $_: math-pow-polyfill(1.4, 718273);
}
```

Runtime decreased from 5s to 0.025s. This version is also significantly shorter.

The trick is to avoid duplicate work. For example the maclaurin formular for exp is:

```
sum(x**i / x!)
```

The previous version calculated `x**i` and `x!` in every step. The new version saves the value from the previous step and just multiplies it with `x / i`.